### PR TITLE
ci: 仅主分支推送时同步产物到子仓库

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,7 +146,7 @@ jobs:
 
       # 同步产物到子仓库
       - name: Sync Artifacts to Sub Repository
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: plugin
         env:
           ARTIFACTS_TOKEN: ${{ secrets.ARTIFACTS_TOKEN }}


### PR DESCRIPTION
移除 release 分支的触发条件，简化同步逻辑