### PR TITLE
fix: 处理GitLab适配器返回JSON而非diff内容的情况

### DIFF
--- a/diffsense/adapters/gitlab_adapter.py
+++ b/diffsense/adapters/gitlab_adapter.py
@@ -39,6 +39,12 @@ class GitLabAdapter(PlatformAdapter):
             response = requests.get(diff_url, headers=headers)
             response.raise_for_status()
             content = response.text
+            
+            # Validation: Check if it's JSON (API error or wrong endpoint behavior)
+            if content.strip().startswith('{') and '"id":' in content:
+                 print("Warning: .diff endpoint returned JSON. Falling back to changes API.")
+                 return self._fetch_diff_fallback()
+
             if not content.strip():
                  print("Warning: Raw diff is empty. Trying fallback to changes API.")
                  return self._fetch_diff_fallback()

--- a/diffsense/core/parser.py
+++ b/diffsense/core/parser.py
@@ -10,6 +10,14 @@ class DiffParser:
         stats = {"add": 0, "del": 0}
         file_patches = []
         
+        # Check if content looks like JSON (GitLab API response leak)
+        if diff_content.strip().startswith('{') or diff_content.strip().startswith('['):
+            # It seems we got raw JSON instead of diff text.
+            # This happens if the fetcher returned API response text directly.
+            # Let's try to handle this edge case or return empty to fail safely.
+            print("Warning: Diff content looks like JSON. Parser expects Unified Diff format.")
+            return {"files": [], "file_patches": [], "stats": stats, "change_types": [], "raw_diff": diff_content}
+
         lines = diff_content.splitlines()
         current_file = None
         current_patch_lines = []


### PR DESCRIPTION
当GitLab的.diff端点意外返回JSON响应时，适配器现在会检测并回退到changes API获取正确的diff内容。同时在解析器中添加防护，避免JSON内容被误解析为diff格式。