### PR TITLE
fix(renderer): 修复高风险详情渲染中的空行问题并调整输入结构

### DIFF
--- a/diffsense/core/renderer.py
+++ b/diffsense/core/renderer.py
@@ -10,17 +10,19 @@ class MarkdownRenderer:
         
         lines = []
         
-        if review_level == "Elevated":
+        if review_level in ["Elevated", "Critical"]:
             lines.append(f"# 🚨 DiffSense Risk Signal: {review_level}")
             lines.append("")
             lines.append("**Detected high-risk changes:**")
             
             for d in details:
-                if d.get('severity') == 'high':
+                # Assuming details is a list of impact dicts
+                # Adjust based on what ImpactEvaluator returns
+                severity = d.get('severity', 'unknown')
+                if severity == 'high' or severity == 'critical':
                     lines.append(f"- **Dimension:** {d.get('impact', 'Unknown').capitalize()}")
                     lines.append(f"- **Rule:** `{d.get('rule_id')}`")
                     lines.append(f"- **File:** `{d.get('file')}`")
-                    lines.append("")
                     lines.append(f"> **Rationale:** {d.get('rationale')}")
                     lines.append("")
             


### PR DESCRIPTION
修复 MarkdownRenderer 中当 review_level 为 "Critical" 时未触发高风险信号的问题。 将高风险详情渲染逻辑中的空行位置调整至每个条目后，以避免格式错误。
同时调整 run_audit.py 中传递给渲染器的数据结构，确保其包含正确的 review_level 和 details 字段。