### PR TITLE
feat(rules): migrate Go rules to YAML configuration and update CLI op…

### DIFF
--- a/diffsense/cli.py
+++ b/diffsense/cli.py
@@ -430,7 +430,7 @@ def benchmark_cold_hot(
 def benchmark(
     manifest: str = typer.Option("benchmarks/manifest.yaml", "--manifest", "-m", help="Benchmark manifest YAML path"),
     output: str = typer.Option("benchmarks/benchmark_report.json", "--output", "-o", help="Benchmark report JSON output path"),
-    rules: str = typer.Option("config/rules.yaml", "--rules", help="Path to rules: single YAML file or directory of YAML files"),
+    rules: str = typer.Option("config", "--rules", help="Path to rules: single YAML file or directory of YAML files"),
     profile: str = typer.Option(None, "--profile", help="Profile: strict or lightweight"),
     experimental: bool = typer.Option(False, "--experimental", help="Include experimental rules (report-only by default)"),
     experimental_report_only: bool = typer.Option(True, "--experimental-report-only/--experimental-affect-decision", help="Do not affect decision with experimental rules"),

--- a/diffsense/config/rules/go/exception_error_ignored.yaml
+++ b/diffsense/config/rules/go/exception_error_ignored.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: exception.error_ignored
+    language: go
+    severity: medium
+    impact: maintenance
+    file: "**/*.go"
+    match: '_\s*=\s*\w+\s*\([^)]*\)'
+    rationale: "Error result is discarded in Go code; silent failures can hide operational issues and data corruption."

--- a/diffsense/config/rules/go/null_nil_dereference.yaml
+++ b/diffsense/config/rules/go/null_nil_dereference.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: null.nil_dereference
+    language: go
+    severity: high
+    impact: runtime
+    file: "**/*.go"
+    match: '\*\s*\w+|\w+\s*\.\s*\w+\s*\('
+    rationale: "Potential nil dereference pattern introduced; verify pointer and receiver nil checks near call site."

--- a/diffsense/config/rules/go/resource_channel_leak.yaml
+++ b/diffsense/config/rules/go/resource_channel_leak.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: resource.channel_leak
+    language: go
+    severity: high
+    impact: runtime
+    file: "**/*.go"
+    match: 'make\s*\(\s*chan|chan\s+\w+\s*='
+    rationale: "Channel allocation introduced; verify close semantics and ownership to avoid goroutine blocking or leaks."

--- a/diffsense/config/rules/go/resource_defer_misuse.yaml
+++ b/diffsense/config/rules/go/resource_defer_misuse.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: resource.defer_misuse
+    language: go
+    severity: medium
+    impact: runtime
+    file: "**/*.go"
+    match: 'for\s*\{[\s\S]{0,200}\bdefer\s+|defer\s+\w+\s*\(\s*\w+\s*[+\-*/]'
+    rationale: "Defer in loop or defer with eager-evaluated expressions may cause resource retention and delayed release."

--- a/diffsense/config/rules/go/resource_goroutine_leak.yaml
+++ b/diffsense/config/rules/go/resource_goroutine_leak.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: resource.goroutine_leak
+    language: go
+    severity: high
+    impact: runtime
+    file: "**/*.go"
+    match: '\bgo\s+\w+\.?\w*\s*\('
+    rationale: "Goroutine started without clear lifecycle constraints may leak and accumulate runtime pressure."

--- a/diffsense/config/rules/go/runtime_goroutine_in_loop.yaml
+++ b/diffsense/config/rules/go/runtime_goroutine_in_loop.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: go.runtime.goroutine_in_loop
+    language: go
+    severity: high
+    impact: runtime
+    file: "**/*.go"
+    match: 'for\s*\{[\s\S]{0,200}\bgo\s+\w'
+    rationale: "Goroutine launched inside loop may create unbounded concurrency; add backpressure or worker-pool controls."

--- a/diffsense/config/rules/go/runtime_panic_added.yaml
+++ b/diffsense/config/rules/go/runtime_panic_added.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: go.runtime.panic_added
+    language: go
+    severity: medium
+    impact: runtime
+    file: "**/*.go"
+    match: '\bpanic\s*\('
+    rationale: "panic() added in Go code; ensure panic is not used for recoverable errors in request paths."

--- a/diffsense/config/rules/go/runtime_race_condition.yaml
+++ b/diffsense/config/rules/go/runtime_race_condition.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: runtime.race_condition
+    language: go
+    severity: high
+    impact: runtime
+    file: "**/*.go"
+    match: '\bgo\s+\w+|\bmap\[|\bslice\b|\bchan\b'
+    rationale: "Concurrent access patterns introduced without explicit synchronization can cause race conditions."

--- a/diffsense/config/rules/go/security_command_injection.yaml
+++ b/diffsense/config/rules/go/security_command_injection.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: go.security.command_injection
+    language: go
+    severity: high
+    impact: security
+    file: "**/*.go"
+    match: 'exec\.Command\('
+    rationale: "Command execution introduced in Go code; verify user input is sanitized to avoid command injection."

--- a/diffsense/config/rules/go/security_hardcoded_secret.yaml
+++ b/diffsense/config/rules/go/security_hardcoded_secret.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: go.security.hardcoded_secret
+    language: go
+    severity: critical
+    impact: security
+    file: "**/*.go"
+    case_insensitive: true
+    match: '(password|passwd|secret|token|api[_-]?key)\s*[:=]\s*"[^"]{8,}"'
+    rationale: "Hardcoded secrets detected in Go source; move credentials to environment variables or secret managers."

--- a/diffsense/config/rules/go/security_http_vulnerability.yaml
+++ b/diffsense/config/rules/go/security_http_vulnerability.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: security.http_vulnerability
+    language: go
+    severity: high
+    impact: security
+    file: "**/*.go"
+    match: 'http\.(Get|Post)\s*\([^)]*\+|http\.ListenAndServe\s*\('
+    rationale: "HTTP flow with path concatenation or direct ListenAndServe exposure may introduce security vulnerabilities."

--- a/diffsense/config/rules/go/security_path_traversal.yaml
+++ b/diffsense/config/rules/go/security_path_traversal.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: go.security.path_traversal
+    language: go
+    severity: high
+    impact: security
+    file: "**/*.go"
+    match: '(?:os\.Open|os\.ReadFile|ioutil\.ReadFile)\([^)]*\+'
+    rationale: "File path concatenation with external input can lead to path traversal; use filepath.Clean and strict allowlists."

--- a/diffsense/config/rules/go/security_sql_injection.yaml
+++ b/diffsense/config/rules/go/security_sql_injection.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: go.security.sql_injection
+    language: go
+    severity: critical
+    impact: security
+    file: "**/*.go"
+    match: 'fmt\.Sprintf\(\s*"(?:SELECT|INSERT|UPDATE|DELETE)\b'
+    rationale: "Dynamic SQL composition via fmt.Sprintf in Go introduces SQL injection risk; use parameterized queries."

--- a/diffsense/config/rules/go/security_unsafe_usage.yaml
+++ b/diffsense/config/rules/go/security_unsafe_usage.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: security.unsafe_usage
+    language: go
+    severity: high
+    impact: security
+    file: "**/*.go"
+    match: '\bunsafe\.(Pointer|Sizeof|Alignof|Offsetof)\s*\('
+    rationale: "Unsafe package usage bypasses type and memory safety guarantees; review pointer arithmetic and casting carefully."

--- a/diffsense/config/rules/typescript/exception_promise_reject.yaml
+++ b/diffsense/config/rules/typescript/exception_promise_reject.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: typescript.exception.promise_reject
+    language: typescript
+    severity: medium
+    impact: runtime
+    file: "**/*.ts*"
+    match: 'new\s+Promise\(|Promise\.reject\('
+    rationale: "Promise rejection path introduced; verify rejection is awaited or handled to avoid unhandled rejection."

--- a/diffsense/config/rules/typescript/maintenance_debugger.yaml
+++ b/diffsense/config/rules/typescript/maintenance_debugger.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: typescript.maintenance.debugger
+    language: typescript
+    severity: low
+    impact: maintenance
+    file: "**/*.ts*"
+    match: '\bdebugger\b'
+    rationale: "Debugger statement left in TypeScript production path can disrupt runtime behavior."

--- a/diffsense/config/rules/typescript/security_command_injection.yaml
+++ b/diffsense/config/rules/typescript/security_command_injection.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: typescript.security.command_injection
+    language: typescript
+    severity: critical
+    impact: security
+    file: "**/*.ts*"
+    match: 'child_process\.(exec|execSync|spawn)\('
+    rationale: "Process execution API introduced in TypeScript; unsanitized input can lead to command injection."

--- a/diffsense/config/rules/typescript/security_hardcoded_secret.yaml
+++ b/diffsense/config/rules/typescript/security_hardcoded_secret.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: typescript.security.hardcoded_secret
+    language: typescript
+    severity: critical
+    impact: security
+    file: "**/*.ts*"
+    case_insensitive: true
+    match: '(password|passwd|secret|token|api[_-]?key)\s*[:=]\s*["''][^"'']{8,}["'']'
+    rationale: "Hardcoded credential-like value in TypeScript detected; move to secure runtime secret storage."

--- a/diffsense/config/rules/typescript/security_prototype_pollution.yaml
+++ b/diffsense/config/rules/typescript/security_prototype_pollution.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: typescript.security.prototype_pollution
+    language: typescript
+    severity: high
+    impact: security
+    file: "**/*.ts*"
+    match: '__proto__|prototype\['
+    rationale: "Prototype mutation path introduced in TypeScript may enable prototype pollution attacks."

--- a/diffsense/config/rules/typescript/security_xss.yaml
+++ b/diffsense/config/rules/typescript/security_xss.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: typescript.security.xss
+    language: typescript
+    severity: high
+    impact: security
+    file: "**/*.ts*"
+    match: 'innerHTML|dangerouslySetInnerHTML'
+    rationale: "DOM HTML injection sink introduced in TypeScript; sanitize or encode untrusted input to prevent XSS."

--- a/diffsense/core/rules.py
+++ b/diffsense/core/rules.py
@@ -120,20 +120,8 @@ try:
 except ImportError:
     API_RULES_AVAILABLE = False
 
-try:
-    from rules.go_rules import (
-        GoGoroutineLeakRule,
-        GoChannelLeakRule,
-        GoDeferMisuseRule,
-        GoUnsafeUsageRule,
-        GoErrorHandlingRule,
-        GoNilPointerRule,
-        GoRaceConditionRule,
-        GoHTTPSecurityRule,
-    )
-    GO_RULES_AVAILABLE = True
-except ImportError:
-    GO_RULES_AVAILABLE = False
+# Go 规则已迁移到 YAML 配置
+GO_RULES_AVAILABLE = False
 
 # Python/C++/JavaScript 规则已迁移到 YAML 配置
 # 参见 diffsense/config/rules/ 目录
@@ -236,17 +224,7 @@ class RuleEngine:
             self.rules.append(DeprecatedApiAddedRule())
             self.rules.append(SerialVersionUIDChangedRule())
         
-        if GO_RULES_AVAILABLE:
-            self.rules.append(GoGoroutineLeakRule())
-            self.rules.append(GoChannelLeakRule())
-            self.rules.append(GoDeferMisuseRule())
-            self.rules.append(GoUnsafeUsageRule())
-            self.rules.append(GoErrorHandlingRule())
-            self.rules.append(GoNilPointerRule())
-            self.rules.append(GoRaceConditionRule())
-            self.rules.append(GoHTTPSecurityRule())
-
-        # Python/C++/JavaScript 规则已迁移到 YAML 配置
+        # Python/C++/JavaScript/Go 规则已迁移到 YAML 配置
         # 参见 diffsense/config/rules/ 目录
 
         # Cross-language rules (Python, JavaScript, C++)

--- a/diffsense/main.py
+++ b/diffsense/main.py
@@ -99,7 +99,7 @@ def _write_json(path: str, data: Any) -> None:
 def main():
     parser = argparse.ArgumentParser(description="DiffSense: Event-driven MR Audit Analyzer")
     parser.add_argument("diff_file", help="Path to the diff file")
-    parser.add_argument("--rules", default="config/rules.yaml", help="Path to rules: single YAML file or directory of YAML files")
+    parser.add_argument("--rules", default="config", help="Path to rules: single YAML file or directory of YAML files")
     parser.add_argument("--format", choices=["json", "markdown"], default="json", help="Output format")
     parser.add_argument("--profile", default=None, help="Profile: strict or lightweight")
     parser.add_argument("--baseline", action="store_true", help="Generate baseline file for existing issues")

--- a/diffsense/rules/RULES_README.md
+++ b/diffsense/rules/RULES_README.md
@@ -111,7 +111,7 @@
 | `runtime.race_condition` | High | Regression | 检测竞态条件风险（共享变量无锁保护） |
 | `security.http_vulnerability` | High | Absolute | 检测 HTTP 安全问题（路径遍历、未验证输入等） |
 
-> 注意：Go 规则使用基于正则的轻量级检测。更多语义级检测请参考 `parsers/go_ast_parser.py`。
+> 注意：Go 规则现已 YAML 化，规则文件位于 `config/rules/go/`；`go_rules.py` 仅保留兼容代码，不再作为默认加载来源。
 
 ---
 
@@ -202,8 +202,15 @@ diffsense/rules/
 ├── null_safety.py                 # 空安全规则 (6 条)
 ├── collection_handling.py         # 集合处理规则 (7 条)
 ├── api_compatibility.py           # API 兼容性规则 (8 条)
-├── go_rules.py                    # Go 语言规则 (8 条)
+├── go_rules.py                    # Go 旧版实现（兼容保留，默认不加载）
 └── yaml_adapter.py                # YAML 规则适配器
+
+diffsense/config/rules/
+├── go/*.yaml                      # Go 规则（默认加载）
+├── python/*.yaml                  # Python 规则
+├── javascript/*.yaml              # JavaScript 规则
+├── typescript/*.yaml              # TypeScript 规则
+└── cpp/*.yaml                     # C/C++ 规则
 
 diffsense/sdk/
 ├── rule.py                        # BaseRule 抽象类

--- a/diffsense/rules/__init__.py
+++ b/diffsense/rules/__init__.py
@@ -71,18 +71,7 @@ from rules.api_compatibility import (
     SerialVersionUIDChangedRule,
 )
 
-from rules.go_rules import (
-    GoGoroutineLeakRule,
-    GoChannelLeakRule,
-    GoDeferMisuseRule,
-    GoUnsafeUsageRule,
-    GoErrorHandlingRule,
-    GoNilPointerRule,
-    GoRaceConditionRule,
-    GoHTTPSecurityRule,
-)
-
-# Python、C++、JavaScript 规则已迁移到 YAML 配置
+# Python、C++、JavaScript、Go 规则已迁移到 YAML 配置
 # 参见 diffsense/config/rules/ 目录
 
 # Cross-language rules (support multiple languages)
@@ -146,22 +135,12 @@ BUILTIN_RULES = [
     AnnotationRemovedRule,
     DeprecatedApiAddedRule,
     SerialVersionUIDChangedRule,
-    
-    # Go Language Rules (8 rules)
-    GoGoroutineLeakRule,
-    GoChannelLeakRule,
-    GoDeferMisuseRule,
-    GoUnsafeUsageRule,
-    GoErrorHandlingRule,
-    GoNilPointerRule,
-    GoRaceConditionRule,
-    GoHTTPSecurityRule,
-    
-    # Python/C++/JavaScript 规则已迁移到 YAML 配置
+
+    # Python/C++/JavaScript/Go 规则已迁移到 YAML 配置
     # 参见 diffsense/config/rules/ 目录
 ]
 
-# Total: 44 built-in rules + cross-language rules
+# Total: 36 built-in rules + cross-language rules
 
 # Cross-language rule support (Python, JavaScript, C++)
 CROSS_LANGUAGE_RULES_LIST = []
@@ -243,17 +222,6 @@ def get_rules_by_category(category: str):
             AnnotationRemovedRule,
             DeprecatedApiAddedRule,
             SerialVersionUIDChangedRule,
-        ],
-        
-        'go': [
-            GoGoroutineLeakRule,
-            GoChannelLeakRule,
-            GoDeferMisuseRule,
-            GoUnsafeUsageRule,
-            GoErrorHandlingRule,
-            GoNilPointerRule,
-            GoRaceConditionRule,
-            GoHTTPSecurityRule,
         ],
     }
     

--- a/diffsense/run_audit.py
+++ b/diffsense/run_audit.py
@@ -390,7 +390,7 @@ def main():
     parser.add_argument("--mr-iid", type=int, help="GitLab Merge Request IID")
     
     # Config
-    parser.add_argument("--rules", default="config/rules.yaml", help="Path to rules: single YAML file or directory")
+    parser.add_argument("--rules", default="config", help="Path to rules: single YAML file or directory")
     parser.add_argument("--profile", default=None, help="Profile: strict or lightweight")
     parser.add_argument("--baseline", action="store_true", help="Generate baseline file for existing issues")
     parser.add_argument("--since-baseline", action="store_true", help="Only report findings not in baseline")


### PR DESCRIPTION
…tions

- Updated the CLI options to accept a directory for rules instead of a single YAML file, enhancing flexibility in rule management.
- Migrated existing Go rules from Python classes to YAML files for better organization and maintainability.
- Added multiple new Go and TypeScript rules focusing on security and runtime issues, improving the overall analysis capabilities.
- Updated documentation to reflect the changes in rule structure and configuration.